### PR TITLE
chore: :see_no_evil: add more things for Git to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_Store
 .Rproj.user
+/.quarto/
+_book
+.Rapp.history
+.Rhistory
+.RData


### PR DESCRIPTION
The `.Rapp.history` file isn't needed and shouldn't be tracked. So I added it to the `.gitignore` file and added some other items to it too that shouldn't be included in the Git history.