### PR TITLE
style: :art: formatting and minor stylistic edits

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,10 +1,4 @@
----
-editor: 
-  markdown: 
-    wrap: 72
----
-
-# Welcome to the 2025 Steno Aarhus Diabetes Demography Symposium
+# Welcome!
 
 ## Date and time
 
@@ -16,7 +10,7 @@ editor:
 
 ## Location
 
-::: callout-note
+::: {.callout-note icon="false"}
 ## 🏛️ Aarhus University
 
 Eduard Biermann Auditorium [(Building 1252, Room
@@ -50,7 +44,7 @@ development of methods, education and joint research in the field.
 ## Speakers
 
 | Name | Affiliation | Status |
-|------------------------|------------------------|------------------------|
+|----|----|----|
 | Prof. Sarah Wild | University of Edinburgh, UK | confirmed |
 | Prof. Dianna Magliano | Baker Heart and Diabetes Institute, Melbourne, Australia (and visiting professor in Denmark in 2025) | confirmed |
 | Prof. Edward Gregg | Imperial College London, UK and Royal College of Surgeons in Ireland, Dublin, Ireland | confirmed |
@@ -60,7 +54,7 @@ development of methods, education and joint research in the field.
 ## Program (draft)
 
 | Start | End | Title | Speaker |
-|------------------|------------------|------------------|------------------|
+|----|----|----|----|
 | *09:30* | *10:00* | *Coffee* | *-* |
 | 10:00 | 10:15 | Welcome and Introduction | Daniel Witte / Henrik Støvring |
 | 10:15 | 10:50 |  | Dianna Magliano |
@@ -76,6 +70,8 @@ development of methods, education and joint research in the field.
 | 15:00 | 15:35 |  | Bendix Carstensen |
 | 15:35 | 16:15 | Discussion: What is the roadmap for future collaboration on this work? | All |
 | 16:15 |  | Final words and end of seminar |  |
+
+: Potential schedule {tbl-colwidths="\[15,15,40,30\]" .striped}
 
 ### The target audience
 

--- a/materials.qmd
+++ b/materials.qmd
@@ -1,13 +1,10 @@
----
-title: "Materials"
-editor: visual
----
+# Materials
 
 ## Background materials for the Diabetes Demography Symposium
 
 This page will contain the materials participants will be asked to go
 through before attending the symposium. This may contain references to
 background reading, links to code or examples of particular types of
-analyes.
+analyses.
 
 ## Background Reading

--- a/profiles.qmd
+++ b/profiles.qmd
@@ -1,11 +1,6 @@
----
-title: "Speaker Profiles"
-editor: visual
----
+# Speaker Profiles
 
-## Short speaker profiles
-
-### Prof. Dianna Magliano, PhD, OAM
+## Prof. Dianna Magliano, PhD, OAM
 
 Professor Dianna Magliano has a BAppSci (Hons), PhD, and a Master of
 Public Health. Professor Magliano has worked for over 20 years in
@@ -20,7 +15,7 @@ Datasets to Answer Questions on Diabetes Epidemiology – International
 Centre for Population-Based Diabetes Research (IPoD) funded by the DDEA
 (Danish Diabetes and Endocrine Academy).
 
-### Mr. Bendix Carstensen, MSc.
+## Mr. Bendix Carstensen, MSc.
 
 Bendix Carstensen has been a senior statistician at Steno Diabetes
 Center Copenhagen since 1999. He holds a degree in mathematical
@@ -31,7 +26,7 @@ of "Epidemiology with R" (OUP, 2021). He has extensive experience with
 international collaborations on monitoring and modelling of diabetes
 epidemiology and demography. Current H-index: 59
 
-### Dr. Edward W Gregg, PhD
+## Dr. Edward W Gregg, PhD
 
 Edward Gregg holds dual appointments at Imperial College London, UK
 (School of Public Health), and the Royal College of Surgeons in Ireland.
@@ -45,7 +40,7 @@ recent trends in the diabetes epidemic and the impact of lifestyle
 interventions and related health policies on diabetes, cardiovascular
 disease, and ageing-related outcomes.
 
-### Prof. Henrik Støvring, PhD
+## Prof. Henrik Støvring, PhD
 
 Henrik Støvring has investigated the diabetes epidemic in Denmark during
 the 1990s using pharmacoepidemiologic data and showed how projections of


### PR DESCRIPTION
These are very minor, but they help to make the website look and work a bit better.

- I made the first two columns of the program be smaller, and the other two larger. Plus gave it a stripe to make it easier to view, but that's entirely personal, you can remove it by removing the `.striped` from the table caption section.
- Since it is a book format, it works best (I think because of it generating the `sec-` labels) that the title of the page be a `# ` header rather than in the YAML with `title: `.